### PR TITLE
add hashing and other various error handlers

### DIFF
--- a/beauty-consulting-app/app/Pages/SignInPage.js
+++ b/beauty-consulting-app/app/Pages/SignInPage.js
@@ -26,7 +26,7 @@ const SignInPage = () => {
                 return;
             }
             const res = await axios.post(apiUrl + ':5050/account/signIn', req);
-            console.log("Sign in successful: " + res.data.username);
+            console.log("Sign in successful: " + res.data);
         } catch (error) {
             console.error('Error with Sign In: ', error.response.data);
             return;

--- a/server/model/account.js
+++ b/server/model/account.js
@@ -1,14 +1,30 @@
 import mongoose from "mongoose";
+import crypto from "crypto";
 
 const AccountSchema = new mongoose.Schema({
     username: {
         type: String,
         required: true
     },
-    password: {
-        type: String,
-    }
+    hash: String,
+    salt: String
 });
+
+AccountSchema.methods.createHashedPassword = function (password) {
+    // Creating a unique salt for a particular user
+    this.salt = crypto.randomBytes(16).toString('hex');
+ 
+    // Hashing user's salt and password with 1000 iterations,
+    // 64 length and sha512 digest
+    this.hash = crypto.pbkdf2Sync(password, this.salt,
+        1000, 64, `sha512`).toString(`hex`);
+}
+
+AccountSchema.methods.validateHashedPassword = function (password) {
+    var hash = crypto.pbkdf2Sync(password,
+        this.salt, 1000, 64, `sha512`).toString(`hex`);
+    return this.hash === hash;
+}
 
 const ResetPasswordSchema = new mongoose.Schema({
     email: {


### PR DESCRIPTION
- Replace plaintext password field in Account DB schema with hash and salt fields
- Add methods to mongoose Account Schema for creating hashed password and checking stored hash/salt against a string password
- Add a couple more error handling things like checking for whitespace and null field entries