### PR TITLE
Add file to (mostly) ignore formatting commits from git blames.

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# First time applying prettier in PR #45
+f70e5e11381746be2bdafbff3320916ec227a3bb
+# Apply Prettier with config in PR #46
+554d2bf056af36049be5d88726c3481546b17c30
+# Apply Prettier with new options in PR #46
+f2758b90975915eb73fdf584a23fc15963eacf4a
+# Fix formatting on PR #54
+37f11215ed4f3309c07097a150cf46c566a67c71


### PR DESCRIPTION
While it was necessary to apply big Prettier formatting commits in #45 and #46, these messed up the git blames for all the files. This makes it hard to trace the authors of code with git blame, which is useful when you are confused about some code and need to some clarification from the author. This PR creates a file that causes git blame to (mostly) ignores the formatting commits. Future formatting commits can be added to this file as well.

See [Github Documentation](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view) reference.