### PR TITLE
[BUGFIX] Prevent Double Booking

### DIFF
--- a/beauty-consulting-app/app/Pages/Directory.js
+++ b/beauty-consulting-app/app/Pages/Directory.js
@@ -110,6 +110,14 @@ const Directory = () => {
 				duration: 60,
 				notes: "",
 			};
+			const res = await api.get(
+				`/appointment/checkBooking?stylistUsername=${req.stylistUsername}&dateTime=${req.appointmentDate}`
+			);
+			if (!res.data.available) {
+				// TODO: handle error better
+				console.error("APPOINTMENT NOT AVAILABLE AT TIME ");
+				return;
+			}
 			console.log(req);
 			await api.post("/appointment/create", req);
 			setModalVisible(false);

--- a/server/API Routes.md
+++ b/server/API Routes.md
@@ -80,5 +80,11 @@
     -   **Description**: Marks an appointment as completed by appointment ID.
 
 -   **Check Date Availability for Stylist**
+
     -   **GET** `/appointment/availability?username={id}&month={monthNumber}`
     -   **Description**: Checks availability for each date in a specified month for a stylist.
+
+-   **Check Booking Availability for Stylist**
+
+    -   **GET** `/appointment/checkbooking?stylistUsername={username}&dateTime={dateTime}
+    -   **Description**: Checks if an appointment already exists with that stylist at that time.

--- a/server/API Routes.md
+++ b/server/API Routes.md
@@ -86,5 +86,5 @@
 
 -   **Check Booking Availability for Stylist**
 
-    -   **GET** `/appointment/checkbooking?stylistUsername={username}&dateTime={dateTime}
+    -   **GET** `/appointment/checkbooking?stylistUsername={username}&dateTime={dateTime}`
     -   **Description**: Checks if an appointment already exists with that stylist at that time.

--- a/server/route/AppointmentController.js
+++ b/server/route/AppointmentController.js
@@ -98,6 +98,42 @@ router.get(
 	})
 );
 
+// Endpoint that checks if appointment with stylist at same time is available or not
+router.get(
+	"/checkbooking",
+	asyncHandler(async (req, res, next) => {
+		const { stylistUsername, dateTime } = req.query;
+
+		if (!stylistUsername || !dateTime) {
+			return next(
+				new MalformedRequestError(
+					"Both Stylist Username and DateTime are required."
+				)
+			);
+		}
+		let appointments;
+		if (stylistUsername) {
+			appointments = await Appointment.find({
+				stylistUsername: stylistUsername,
+				appointmentDate: dateTime,
+				status: { $ne: "Canceled" },
+			});
+		} else {
+			return next(
+				new ConflictError(
+					`User with username ${stylistUsername} not found.`
+				)
+			);
+		}
+
+		if (appointments && appointments.length > 0) {
+			res.json({ available: false });
+		} else {
+			res.json({ available: true });
+		}
+	})
+);
+
 // Endpoint to mark an appointment as completed
 router.put(
 	"/:id/complete",


### PR DESCRIPTION
Prevents double booking with same stylist at same time.

Technically, does not have the logic to check if other appointment's durations fall into the requested appointment, but I think we can get away with this implementation.

future work:
* make error handling prettier, but that would require passing an error message to the modal and that seems a bit tricky, unless I'm thinking about it wrong