### PR TITLE
Prevent Double Booking in Multiple Ways

### DIFF
--- a/beauty-consulting-app/app/Pages/Directory.js
+++ b/beauty-consulting-app/app/Pages/Directory.js
@@ -93,8 +93,8 @@ const Directory = () => {
 	 * done in this file so we don't have to pass state around
 	 */
 	const handleBookPress = (stylistUsername) => {
-		setModalVisible(true);
 		setCurrentStylist(stylistUsername);
+		setModalVisible(true);
 	};
 
 	const createAppointment = async (date, time) => {
@@ -110,6 +110,14 @@ const Directory = () => {
 				duration: 60,
 				notes: "",
 			};
+			const res = await api.get(
+				`/appointment/checkBooking?stylistUsername=${req.stylistUsername}&dateTime=${req.appointmentDate}`
+			);
+			if (!res.data.available) {
+				// TODO: handle error better
+				console.error("APPOINTMENT NOT AVAILABLE AT TIME ");
+				return;
+			}
 			console.log(req);
 			await api.post("/appointment/create", req);
 			setModalVisible(false);
@@ -209,6 +217,7 @@ const Directory = () => {
 							visible={modalVisible}
 							onClose={hideModal}
 							onCreateAppointment={createAppointment}
+							stylistUsername={currentStylist}
 						/>
 					) : null}
 				</View>

--- a/beauty-consulting-app/app/assets/components/appointmentModal.js
+++ b/beauty-consulting-app/app/assets/components/appointmentModal.js
@@ -9,32 +9,48 @@ import {
 } from "react-native";
 import globalStyles from "../GlobalStyles";
 import MyCalendar from "./Calendar";
+import api from "utils/axios";
 
-const AppointmentModal = ({ visible, onClose, onCreateAppointment }) => {
+const AppointmentModal = ({
+	visible,
+	onClose,
+	onCreateAppointment,
+	stylistUsername,
+}) => {
 	const [selectedDay, setSelectedDay] = useState(null);
 	const [selectedTime, setSelectedTime] = useState(null);
+	const [timeSlots, setTimeSlots] = useState([]);
 
-	const handleDaySelect = (day) => {
+	const handleDaySelect = async (day) => {
 		setSelectedDay(day.dateString);
 		setSelectedTime(null);
+		availableTimes = await generateTimeSlots(day.dateString);
+		setTimeSlots(availableTimes);
 	};
 
-	const generateTimeSlots = () => {
+	const generateTimeSlots = async (date) => {
 		const slots = [];
 		let startTime = new Date();
 		startTime.setHours(9, 0, 0, 0);
 		const endTime = new Date();
 		endTime.setHours(17, 0, 0, 0);
 
+		const res = await api.get(
+			`/appointment/gettimes?stylistUsername=${stylistUsername}&date=${date}`
+		);
+		const unavailable = res.data.unavailable;
+		console.log(unavailable);
+
 		while (startTime < endTime) {
 			const timeString = startTime.toTimeString().slice(0, 5);
-			slots.push(timeString);
+			if (!unavailable.includes(timeString)) {
+				slots.push(timeString);
+			}
 			startTime.setMinutes(startTime.getMinutes() + 30);
 		}
+
 		return slots;
 	};
-
-	const timeSlots = generateTimeSlots();
 
 	return (
 		<Modal visible={visible} transparent={false} animationType="slide">


### PR DESCRIPTION
prevents double booking checking available times for a stylist, then only displaying those times

also prevents edge case of two users simultaneously opening a stylist's availability for a given day and trying to book within seconds of each other

should fit in with changes to db