### PR TITLE
Fixed creating new chat bug

### DIFF
--- a/server/route/MessagingController.js
+++ b/server/route/MessagingController.js
@@ -150,12 +150,6 @@ router.get(
 			stylistUsername,
 		});
 
-		if (messages.length === 0) {
-			return res.status(200).json({
-				message: "No message history found between client and stylist.",
-			});
-		}
-
 		res.json(messages);
 	})
 );


### PR DESCRIPTION
Fixed the bug where sending a new message would result in a crash

This was due to backend returning { no messages } when messages should be a list instead. Sending a message would append it to the current [], but there wasn't any so it would crash